### PR TITLE
Replacing packaging requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,7 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
-<!--- All unreleased items go here  -->
+## 1.0.6 (03.07.2022)
 
-<!--- Example CHANGELOG entry
-
-## 0.1.0 (2019.07.02)
-
-### Added
-
-- Initial resolver code
-
--->
+### Changed
+- Replaced `packaging` requirement with one for `sceptre>=2.7`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@ bumpversion==0.5.3
 coverage==4.4.2
 pre-commit>=2.12.0,<2.13
 mock==2.0.0
-packaging==16.8
 pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0
 setuptools>=40.6.2
-git+git://github.com/sceptre/sceptre.git@master#egg=sceptre
+sceptre>=2.7
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5
+current_version = 1.0.6
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-file-resolver
@@ -25,8 +25,8 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "packaging==16.8",
-    "requests>=2.25,<3"
+    "requests>=2.25,<3",
+    "sceptre>=2.7"
 ]
 
 test_requirements = [

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -129,7 +129,7 @@ class TestFileResolver(unittest.TestCase):
         self.file_resolver.argument = url_ref
         result = self.file_resolver.resolve()
         result_json = json.dumps(result)
-        expected = '{"Resources": {"WaitConditionHandle": {"Type": "AWS::CloudFormation::WaitConditionHandle", "Properties": null}}}'
+        expected = '{"Resources": {"WaitConditionHandle": {"Type": "AWS::CloudFormation::WaitConditionHandle", "Properties": {}}}}'
         assert expected == result_json
 
     def test_resolving_with_invalid_url_file(self):


### PR DESCRIPTION
We need to remove the pinned version of packaging in order to support updating it in Sceptre. In any case, we shouldn't have ever pinned it. There's nothing in this package that actually makes use of packaging as a requirement.